### PR TITLE
ci: docker-publish.yml to remove PR trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,15 +10,12 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: docker.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -171,7 +171,7 @@ func parseDogStatsDMetricMessage(buf []byte) (DogStatsDMessage, error) {
 
 		if strings.HasPrefix(piece, "#") {
 			tags := strings.Split(piece[1:], ",")
-			for i, _ := range tags {
+			for i := range tags {
 				tags[i] = strings.TrimSpace(tags[i])
 			}
 			metric.Tags = append(metric.Tags, tags...)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"errors"
-	"github.com/charmbracelet/log"
-	"github.com/mroyme/dogstatsd-local/internal/messages"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/mroyme/dogstatsd-local/internal/messages"
 )
 
 type Server interface {
@@ -104,7 +105,7 @@ func (u *udpServer) Listen() error {
 	}
 
 stop:
-	serverConn.Close()
+	_ = serverConn.Close()
 	close(u.stopCh)
 	return nil
 }


### PR DESCRIPTION
Removed pull_request trigger for main branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the PR trigger from the Docker publish workflow and makes minor Go cleanup (ignore UDP Close error, simplify tag loop).
> 
> - **CI**:
>   - Remove `pull_request` trigger from `.github/workflows/docker-publish.yml` to only run on `push` (main/tags).
> - **Server**:
>   - Safely close UDP connection by ignoring `Close` error (`_ = serverConn.Close()`).
> - **Messages**:
>   - Simplify tag trimming loop in `internal/messages/messages.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb78beb96d6478ed9af182681284c7463aaad5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->