### PR TITLE
feat(forwarder): add UDP datagram forwarding to upstream server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,6 +31,6 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/README.md
+++ b/README.md
@@ -5,221 +5,187 @@
 [![SLSA Go releaser](https://github.com/mroyme/dogstatsd-local/actions/workflows/go-ossf-slsa3-publish.yml/badge.svg)](https://github.com/mroyme/dogstatsd-local/actions/workflows/go-ossf-slsa3-publish.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/mroyme/dogstatsd-local?logo=docker)](https://hub.docker.com/r/mroyme/dogstatsd-local)
 
-> A local implementation of the dogstatsd protocol from [Datadog](https://www.datadog.com)
+> A local implementation of the DogStatsD protocol from [Datadog](https://www.datadoghq.com)
 >
-> Up-to-date fork of [jonmorehouse/dogstatsd-local](https://github.com/jonmorehouse/dogstatsd-local)
+> [!NOTE]
+> Started as a fork of [jonmorehouse/dogstatsd-local](https://github.com/jonmorehouse/dogstatsd-local), which was no longer receiving updates. Since then, this project has diverged significantly — adding service check and event support, multiple output formats, Catppuccin-themed colors, metric forwarding, and more.
 
+`dogstatsd-local` listens on a UDP socket, parses DogStatsD (and statsd) metric messages, and outputs them to stdout in your choice of format. Use it to inspect and debug metrics locally before sending them to Datadog.
 
-## Why?
+## Table of Contents
 
-[Datadog](https://www.datadog.com) is great for production application metric aggregation. This project was inspired by the need to inspect and debug metrics _before_ sending them to `datadog`.
+- [Installation](#installation)
+- [Flags](#flags)
+- [Features](#features)
+- [Output Formats](#output-formats)
+  - [Pretty (default)](#pretty-default)
+  - [Short](#short)
+  - [JSON](#json)
+  - [Raw](#raw)
+- [Forwarding](#forwarding)
+- [DogStatsD Protocol](#dogstatsd-protocol)
 
-`dogstatsd-local` is a small program which understands the `dogstatsd` and `statsd` protocols. It listens on a local UDP server and writes metrics, events and service checks per the [dogstatsd protocol](https://docs.datadoghq.com/guides/dogstatsd/) to `stdout` in user configurable formats.
+## Installation
 
-This can be helpful for _debugging_ metrics themselves, and to prevent polluting datadog with noisy metrics from a development environment. **dogstatsd-local** can also be used to pipe metrics as json to other processes for further processing.
+### Go
 
-## Usage
-
-### Install with Go
-
-```
-$ go install github.com/mroyme/dogstatsd-local/cmd/dogstatsd-local@latest
-```
-
-### Build Manually
-
-Run the following command in the source directory.
 ```bash
-$ go build -o bin/dogstatsd-local ./cmd/dogstatsd-local/main.go
+go install github.com/mroyme/dogstatsd-local/cmd/dogstatsd-local@latest
 ```
-
-Once compiled, the `dogstatsd-local` binary can be run directly:
-```bash
-$ ./bin/dogstatsd-local -port=8126
-```
-
-### Prebuilt Binaries
-
-Pre-built binaries for Linux, Mac and Windows are available for x86-64 and AArch64.
-Check out the [releases](https://github.com/mroyme/dogstatsd-local/releases/latest) page.
-
 
 ### Docker
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local
+docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local
 ```
 
-## Sample Formats
+### Prebuilt Binaries
 
-### Pretty 
+Download from the [releases](https://github.com/mroyme/dogstatsd-local/releases/latest) page for Linux, macOS, and Windows (x86-64 and ARM64).
 
-'Pretty' is the default format. When writing a metric such as:
+### Build from Source
 
 ```bash
-$ printf "namespace.metric:1|c|#test" | nc -cu  localhost 8125
+go build -o bin/dogstatsd-local ./cmd/dogstatsd-local/main.go
 ```
 
-Running **dogstatsd-local** with the `-out pretty` flag will parse the UDP packets and print a colorized output:
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-host` | `0.0.0.0` | Bind address |
+| `-port` | `8125` | UDP listen port |
+| `-out` | `pretty` | Output format: `pretty`, `json`, `short`, `raw` |
+| `-forward` | (disabled) | Forward raw datagrams to an upstream DogStatsD server (e.g. `127.0.0.1:8126`) |
+| `-tags` | (empty) | Extra tags to append, comma-delimited |
+| `-max-name-width` | `50` | Max name length for pretty format (values below 50 have no effect) |
+| `-max-value-width` | `15` | Max value length for pretty format |
+| `-debug` | `false` | Enable debug logging |
+
+## Features
+
+- **Metrics** — counters (`c`), gauges (`g`), sets (`s`), timers (`ms`), histograms (`h`), distributions (`d`)
+- **Service checks** — `_sc|name|status|#tags|h:hostname|m:message`
+- **Events** — `_e{titleLen,textLen}:title|text|d:ts|h:host|p:priority|t:alert|k:aggkey|s:src_type|#tags`
+- **Forwarding** — proxy all datagrams to an upstream DogStatsD server with `-forward`
+- **Multi-message datagrams** — splits on `\n` per the DogStatsD protocol
+- **Extra tags** — append tags to every metric with `-tags`
+- **Catppuccin colors** — pretty format adapts to light/dark terminal themes
+
+## Output Formats
+
+### Pretty (default)
+
+Colorized, human-readable output:
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out pretty
-COUNT        namespace | metric                                1.00            test
+printf "page.views:1|c|#env:dev" | nc -u -w1 localhost 8125
 ```
 
-When sending a service check:
-
-```bash
-$ printf "_sc|Redis connection|2|#env:dev|m:Redis connection timed out after 10s" | nc -cu  localhost 8125
+```
+COUNT      page | views                                      1.00           env:dev
 ```
 
-The output is colorized by status (green=OK, yellow=WARN, red=CRIT):
+Service checks are colorized by status (green=OK, yellow=WARN, red=CRIT):
 
 ```bash
-CRIT        Redis connection                       Redis connection timed out after 10s  env:dev
+printf "_sc|Redis connection|2|#env:dev|m:Timeout" | nc -u -w1 localhost 8125
 ```
 
-When sending an event:
-
-```bash
-$ printf "_e{21,36}:An exception occurred|Cannot parse CSV file from 10.0.0.17|t:warning|#err_type:bad_file" | nc -cu  localhost 8125
+```
+CRIT       Redis connection                                  Timeout env:dev
 ```
 
-The output is colorized by alert type (blue=info, yellow=warning, red=error, green=success):
+Events are colorized by alert type (blue=INFO, yellow=WARN, red=ERR, green=OK):
 
 ```bash
-WARN        An exception occurred                  Cannot parse CSV file from 10.0.0.17  err_type:bad_file
+printf "_e{21,36}:An exception occurred|Cannot parse CSV file|t:warning|#err_type:bad_file" | nc -u -w1 localhost 8125
 ```
 
-The output will be colored if your shell supports colors.
-If colors aren't displayed properly, ensure that `TERM` is set correctly in your environment.
-
-Pretty supports the following extra flags:
-- `-max-name-width` (integer): Maximum length of name. Change if name is truncated (default 50)
-- `-max-value-width` (integer): Maximum length of value. Change if value is truncated (default 50)
-- `-debug` (boolean): Enable debug mode (default `false`)
-
-
-### Raw (no formatting)
-
-When writing a metric such as:
-
-```bash
-$ printf "namespace.metric:1|c|#test" | nc -cu  localhost 8125
+```
+WARN       An exception occurred                             Cannot parse CSV file err_type:bad_file
 ```
 
-Running **dogstatsd-local** with the `-out raw` flag will output the plain udp packet:
+### Short
+
+Compact human-readable:
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out raw
-2017/12/03 23:11:31 namespace.metric.name:1|c|@1.00|#tag1
+printf "page.views:1|c|#env:dev" | nc -u -w1 localhost 8125
 ```
 
-### Short 
-
-When writing a metric such as:
-
-```bash
-$ printf "namespace.metric:1|c|#test" | nc -cu  localhost 8125
 ```
-
-Running **dogstatsd-local** with the `-out short` flag will output a short, albeit still human-readable metric:
-
-```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out short
-metric:counter|namespace.metric|1.00  test
-```
-
-When sending a service check:
-
-```bash
-$ printf "_sc|Redis connection|2|#env:dev|m:Redis connection timed out after 10s" | nc -cu  localhost 8125
+metric:count|page.views|1.00 env:dev
 ```
 
 ```bash
-service_check:Redis connection|CRIT|msg:Redis connection timed out after 10s env:dev
+printf "_sc|Redis connection|2|#env:dev|m:Timeout" | nc -u -w1 localhost 8125
 ```
 
-When sending an event:
-
-```bash
-$ printf "_e{21,36}:An exception occurred|Cannot parse CSV file from 10.0.0.17|t:warning|#err_type:bad_file" | nc -cu  localhost 8125
+```
+service_check:Redis connection|CRIT|msg:Timeout env:dev
 ```
 
 ```bash
-event:An exception occurred|Cannot parse CSV file from 10.0.0.17|priority:normal|alert:warning err_type:bad_file
+printf "_e{5,4}:title|text|t:info" | nc -u -w1 localhost 8125
+```
+
+```
+event:title|text|priority:normal|alert:info
 ```
 
 ### JSON
 
-When writing a metric such as:
+Machine-readable, one JSON object per line. Pipe through `jq` for pretty printing:
+
 ```bash
-$ printf "namespace.metric:1|c|#test|extra" | nc -cu  localhost 8125
+printf "page.views:1|c|#env:dev" | nc -u -w1 localhost 8125
 ```
 
-Running **dogstatsd-local** with the `-out json` flag will output json:
-
-```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out json | jq .
-{"namespace":"namespace","name":"metric","path":"namespace.metric","value":1,"extras":["extra"],"sample_rate":1,"tags":["test"]}
-```
-
-When sending a service check:
-
-```bash
-$ printf "_sc|Redis connection|2|#env:dev|m:Redis connection timed out after 10s" | nc -cu  localhost 8125
+```json
+{"namespace":"page","name":"views","path":"page.views","value":1,"sample_rate":1,"tags":["env:dev"]}
 ```
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out json | jq .
-{
-  "name": "Redis connection",
-  "status": "CRIT",
-  "message": "Redis connection timed out after 10s",
-  "tags": [
-    "env:dev"
-  ],
-  "timestamp": 1656581400
-}
+printf "_sc|Redis connection|2|#env:dev|m:Timeout" | nc -u -w1 localhost 8125
 ```
 
-When sending an event:
-
-```bash
-$ printf "_e{21,36}:An exception occurred|Cannot parse CSV file from 10.0.0.17|t:warning|#err_type:bad_file" | nc -cu  localhost 8125
+```json
+{"name":"Redis connection","status":"CRIT","message":"Timeout","tags":["env:dev"],"timestamp":1656581400}
 ```
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out json | jq .
-{
-  "title": "An exception occurred",
-  "text": "Cannot parse CSV file from 10.0.0.17",
-  "priority": "normal",
-  "alert_type": "warning",
-  "tags": [
-    "err_type:bad_file"
-  ],
-  "timestamp": 1656581400
-}
+printf "_e{5,4}:title|text|t:info" | nc -u -w1 localhost 8125
 ```
 
-**dogstatsd-local** can be piped to any process that understands json via stdin. For example, to pretty print JSON with [jq](https://stedolan.github.io/jq/):
+```json
+{"title":"title","text":"text","priority":"normal","alert_type":"info","tags":[]}
+```
+
+### Raw
+
+Passthrough of the original datagram:
 
 ```bash
-$ docker run -it -e "TERM=$TERM" -p 8125:8125/udp mroyme/dogstatsd-local -out json | jq .
-{
-  "namespace": "namespace",
-  "name": "metric",
-  "path": "namespace.metric",
-  "value": 1,
-  "extras": [
-    "extra"
-  ],
-  "sample_rate": 1,
-  "tags": [
-    "test"
-  ]
-}
+printf "page.views:1|c|#env:dev" | nc -u -w1 localhost 8125
 ```
 
-## TODO
+```
+page.views:1|c|#env:dev
+```
+
+## Forwarding
+
+Use `-forward` to proxy all datagrams to an upstream DogStatsD server while still inspecting them locally:
+
+```bash
+dogstatsd-local -forward 127.0.0.1:8126
+```
+
+This is useful for debugging in environments where you still want metrics to reach Datadog.
+
+## DogStatsD Protocol
+
+- **Metrics:** `name:value|type|@sample_rate|#tags` (types: `c` count, `g` gauge, `s` set, `ms` timer, `h` histogram, `d` distribution)
+- **Service checks:** `_sc|name|status|#tags|d:timestamp|h:hostname|m:message` (`m:` must be last, can contain `|`)
+- **Events:** `_e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>|d:<TS>|h:<HOST>|p:<PRIORITY>|t:<ALERT_TYPE>|k:<AGG_KEY>|s:<SRC_TYPE>|#<TAGS>`

--- a/cmd/dogstatsd-local/main.go
+++ b/cmd/dogstatsd-local/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mroyme/dogstatsd-local/internal/format/pretty"
 	"github.com/mroyme/dogstatsd-local/internal/format/raw"
 	"github.com/mroyme/dogstatsd-local/internal/format/short"
+	"github.com/mroyme/dogstatsd-local/internal/forwarder"
 	"github.com/mroyme/dogstatsd-local/internal/messages"
 	"github.com/mroyme/dogstatsd-local/internal/server"
 )
@@ -24,6 +25,7 @@ func main() {
 	host := flag.String("host", "0.0.0.0", "Bind address")
 	port := flag.Int("port", 8125, "Listen port")
 	out := flag.String("out", "pretty", "Output format: json|pretty|raw|short")
+	forward := flag.String("forward", "", "Forward raw datagrams to an upstream DogStatsD server (e.g. 127.0.0.1:8126)")
 	rawTags := flag.String("tags", "", "Extra tags, comma delimited")
 	maxNameWidth := flag.Int("max-name-width", 50,
 		"Maximum length of name. Only used for 'pretty' format, increase if name is truncated."+
@@ -70,11 +72,25 @@ func main() {
 	}
 	messageHandler := asyncMessageHandler.New()
 
+	var forwardFunc func([]byte)
+	var fwd *forwarder.Forwarder
+	if *forward != "" {
+		fwd = &forwarder.Forwarder{
+			Logger:  logger,
+			Address: *forward,
+		}
+		if err := fwd.Start(); err != nil {
+			logger.Fatal("failed to start forwarder", "addr", *forward, "err", err)
+		}
+		logger.Infof("forwarding datagrams to %s", *forward)
+		forwardFunc = fwd.Forward
+	}
+
 	var wg sync.WaitGroup
 
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	logger.Infof("listening over UDP at %s", addr)
-	srv := server.NewServer(addr, messageHandler.Handle, logger)
+	srv := server.NewServer(addr, messageHandler.Handle, forwardFunc, logger)
 	wg.Add(1)
 	go func(srv server.Server) {
 		defer wg.Done()
@@ -89,6 +105,11 @@ func main() {
 
 	if err := srv.Stop(); err != nil {
 		logger.Error(err)
+	}
+	if fwd != nil {
+		if err := fwd.Stop(); err != nil {
+			logger.Error(err)
+		}
 	}
 	wg.Wait()
 	messageHandler.Stop()

--- a/internal/forwarder/forwarder.go
+++ b/internal/forwarder/forwarder.go
@@ -56,15 +56,14 @@ func (f *Forwarder) Start() error {
 
 func (f *Forwarder) Forward(data []byte) {
 	f.mu.Lock()
-	ch := f.ch
-	f.mu.Unlock()
+	defer f.mu.Unlock()
 
-	if ch == nil {
+	if f.ch == nil {
 		return
 	}
 
 	select {
-	case ch <- data:
+	case f.ch <- data:
 	default:
 		if f.Logger != nil {
 			f.Logger.Error("forward buffer full, dropping datagram", "addr", f.Address)

--- a/internal/forwarder/forwarder.go
+++ b/internal/forwarder/forwarder.go
@@ -1,0 +1,58 @@
+package forwarder
+
+import (
+	"net"
+	"sync"
+
+	"github.com/charmbracelet/log"
+)
+
+type Forwarder struct {
+	Logger  *log.Logger
+	Address string
+	conn    *net.UDPConn
+	addr    *net.UDPAddr
+	mu      sync.Mutex
+}
+
+func (f *Forwarder) Start() error {
+	addr, err := net.ResolveUDPAddr("udp", f.Address)
+	if err != nil {
+		return err
+	}
+	f.addr = addr
+
+	conn, err := net.DialUDP("udp", nil, addr)
+	if err != nil {
+		return err
+	}
+	f.conn = conn
+
+	return nil
+}
+
+func (f *Forwarder) Forward(data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.conn == nil {
+		return
+	}
+
+	_, err := f.conn.Write(data)
+	if err != nil {
+		f.Logger.Error("forward error", "addr", f.Address, "err", err)
+	}
+}
+
+func (f *Forwarder) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.conn != nil {
+		err := f.conn.Close()
+		f.conn = nil
+		return err
+	}
+	return nil
+}

--- a/internal/forwarder/forwarder.go
+++ b/internal/forwarder/forwarder.go
@@ -13,7 +13,9 @@ type Forwarder struct {
 	Address string
 	conn    *net.UDPConn
 	started bool
+	ch      chan []byte
 	mu      sync.Mutex
+	wg      sync.WaitGroup
 }
 
 func (f *Forwarder) Start() error {
@@ -34,26 +36,52 @@ func (f *Forwarder) Start() error {
 		return err
 	}
 	f.conn = conn
+	f.ch = make(chan []byte, 10000)
 	f.started = true
+
+	ch := f.ch
+	logger := f.Logger
+
+	f.wg.Go(func() {
+		for data := range ch {
+			_, err := conn.Write(data)
+			if err != nil && logger != nil {
+				logger.Error("forward error", "addr", f.Address, "err", err)
+			}
+		}
+	})
 
 	return nil
 }
 
 func (f *Forwarder) Forward(data []byte) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
+	ch := f.ch
+	f.mu.Unlock()
 
-	if f.conn == nil {
+	if ch == nil {
 		return
 	}
 
-	_, err := f.conn.Write(data)
-	if err != nil {
-		f.Logger.Error("forward error", "addr", f.Address, "err", err)
+	select {
+	case ch <- data:
+	default:
+		if f.Logger != nil {
+			f.Logger.Error("forward buffer full, dropping datagram", "addr", f.Address)
+		}
 	}
 }
 
 func (f *Forwarder) Stop() error {
+	f.mu.Lock()
+	if f.ch != nil {
+		close(f.ch)
+		f.ch = nil
+	}
+	f.mu.Unlock()
+
+	f.wg.Wait()
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/internal/forwarder/forwarder.go
+++ b/internal/forwarder/forwarder.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"errors"
 	"net"
 	"sync"
 
@@ -11,22 +12,29 @@ type Forwarder struct {
 	Logger  *log.Logger
 	Address string
 	conn    *net.UDPConn
-	addr    *net.UDPAddr
+	started bool
 	mu      sync.Mutex
 }
 
 func (f *Forwarder) Start() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.started {
+		return errors.New("forwarder already started")
+	}
+
 	addr, err := net.ResolveUDPAddr("udp", f.Address)
 	if err != nil {
 		return err
 	}
-	f.addr = addr
 
 	conn, err := net.DialUDP("udp", nil, addr)
 	if err != nil {
 		return err
 	}
 	f.conn = conn
+	f.started = true
 
 	return nil
 }
@@ -52,6 +60,7 @@ func (f *Forwarder) Stop() error {
 	if f.conn != nil {
 		err := f.conn.Close()
 		f.conn = nil
+		f.started = false
 		return err
 	}
 	return nil

--- a/internal/forwarder/forwarder_test.go
+++ b/internal/forwarder/forwarder_test.go
@@ -2,7 +2,6 @@ package forwarder
 
 import (
 	"net"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,22 +21,18 @@ func TestForwarderForwardsDatagrams(t *testing.T) {
 	defer func() { _ = upstream.Close() }()
 
 	upstreamAddr := upstream.LocalAddr().String()
-
-	var received atomic.Int32
+	done := make(chan string, 1)
 	buf := make([]byte, 1024)
 
 	// Read forwarded datagrams in background
 	go func() {
-		for {
-			_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
-			n, _, err := upstream.ReadFromUDP(buf)
-			if err != nil {
-				return
-			}
-			if string(buf[:n]) == "page.views:1|c" {
-				received.Add(1)
-			}
+		_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, _, err := upstream.ReadFromUDP(buf)
+		if err != nil {
+			done <- err.Error()
+			return
 		}
+		done <- string(buf[:n])
 	}()
 
 	fwd := &Forwarder{
@@ -51,14 +46,17 @@ func TestForwarderForwardsDatagrams(t *testing.T) {
 
 	fwd.Forward([]byte("page.views:1|c"))
 
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case got := <-done:
+		if got != "page.views:1|c" {
+			t.Errorf("forwarded %q, want %q", got, "page.views:1|c")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for forwarded datagram")
+	}
 
 	if err := fwd.Stop(); err != nil {
 		t.Fatalf("failed to stop forwarder: %v", err)
-	}
-
-	if got := received.Load(); got != 1 {
-		t.Errorf("forwarded %d datagrams, want 1", got)
 	}
 }
 
@@ -106,5 +104,31 @@ func TestForwarderInvalidAddress(t *testing.T) {
 
 	if err := fwd.Start(); err == nil {
 		t.Error("expected error for invalid address, got nil")
+	}
+}
+
+func TestForwarderDoubleStart(t *testing.T) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	upstream, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	fwd := &Forwarder{
+		Logger:  log.Default(),
+		Address: upstream.LocalAddr().String(),
+	}
+
+	if err := fwd.Start(); err != nil {
+		t.Fatalf("failed to start forwarder: %v", err)
+	}
+	defer func() { _ = fwd.Stop() }()
+
+	if err := fwd.Start(); err == nil {
+		t.Error("expected error on double start, got nil")
 	}
 }

--- a/internal/forwarder/forwarder_test.go
+++ b/internal/forwarder/forwarder_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/charmbracelet/log"
 )
 
+type recvResult struct {
+	data []byte
+	err  error
+}
+
 func TestForwarderForwardsDatagrams(t *testing.T) {
 	// Start a UDP server to receive forwarded datagrams
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
@@ -21,7 +26,7 @@ func TestForwarderForwardsDatagrams(t *testing.T) {
 	defer func() { _ = upstream.Close() }()
 
 	upstreamAddr := upstream.LocalAddr().String()
-	done := make(chan string, 1)
+	done := make(chan recvResult, 1)
 	buf := make([]byte, 1024)
 
 	// Read forwarded datagrams in background
@@ -29,10 +34,12 @@ func TestForwarderForwardsDatagrams(t *testing.T) {
 		_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
 		n, _, err := upstream.ReadFromUDP(buf)
 		if err != nil {
-			done <- err.Error()
+			done <- recvResult{err: err}
 			return
 		}
-		done <- string(buf[:n])
+		cp := make([]byte, n)
+		copy(cp, buf[:n])
+		done <- recvResult{data: cp}
 	}()
 
 	fwd := &Forwarder{
@@ -47,9 +54,12 @@ func TestForwarderForwardsDatagrams(t *testing.T) {
 	fwd.Forward([]byte("page.views:1|c"))
 
 	select {
-	case got := <-done:
-		if got != "page.views:1|c" {
-			t.Errorf("forwarded %q, want %q", got, "page.views:1|c")
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("read error: %v", result.err)
+		}
+		if string(result.data) != "page.views:1|c" {
+			t.Errorf("forwarded %q, want %q", string(result.data), "page.views:1|c")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for forwarded datagram")
@@ -94,6 +104,33 @@ func TestForwarderNoopWithoutStart(t *testing.T) {
 
 	// Forward without starting should not panic
 	fwd.Forward([]byte("page.views:1|c"))
+}
+
+func TestForwarderNilLogger(t *testing.T) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	upstream, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	fwd := &Forwarder{
+		Address: upstream.LocalAddr().String(),
+	}
+
+	if err := fwd.Start(); err != nil {
+		t.Fatalf("failed to start forwarder: %v", err)
+	}
+
+	// Should not panic with nil logger
+	fwd.Forward([]byte("page.views:1|c"))
+
+	if err := fwd.Stop(); err != nil {
+		t.Errorf("Stop() returned error: %v", err)
+	}
 }
 
 func TestForwarderInvalidAddress(t *testing.T) {

--- a/internal/forwarder/forwarder_test.go
+++ b/internal/forwarder/forwarder_test.go
@@ -1,0 +1,110 @@
+package forwarder
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+func TestForwarderForwardsDatagrams(t *testing.T) {
+	// Start a UDP server to receive forwarded datagrams
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	upstream, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	upstreamAddr := upstream.LocalAddr().String()
+
+	var received atomic.Int32
+	buf := make([]byte, 1024)
+
+	// Read forwarded datagrams in background
+	go func() {
+		for {
+			_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
+			n, _, err := upstream.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if string(buf[:n]) == "page.views:1|c" {
+				received.Add(1)
+			}
+		}
+	}()
+
+	fwd := &Forwarder{
+		Logger:  log.Default(),
+		Address: upstreamAddr,
+	}
+
+	if err := fwd.Start(); err != nil {
+		t.Fatalf("failed to start forwarder: %v", err)
+	}
+
+	fwd.Forward([]byte("page.views:1|c"))
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := fwd.Stop(); err != nil {
+		t.Fatalf("failed to stop forwarder: %v", err)
+	}
+
+	if got := received.Load(); got != 1 {
+		t.Errorf("forwarded %d datagrams, want 1", got)
+	}
+}
+
+func TestForwarderStops(t *testing.T) {
+	// Start a real upstream to dial to
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to resolve addr: %v", err)
+	}
+	upstream, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = upstream.Close() }()
+
+	fwd := &Forwarder{
+		Logger:  log.Default(),
+		Address: upstream.LocalAddr().String(),
+	}
+
+	if err := fwd.Start(); err != nil {
+		t.Fatalf("failed to start forwarder: %v", err)
+	}
+
+	if err := fwd.Stop(); err != nil {
+		t.Errorf("Stop() returned error: %v", err)
+	}
+}
+
+func TestForwarderNoopWithoutStart(t *testing.T) {
+	fwd := &Forwarder{
+		Logger:  log.Default(),
+		Address: "127.0.0.1:0",
+	}
+
+	// Forward without starting should not panic
+	fwd.Forward([]byte("page.views:1|c"))
+}
+
+func TestForwarderInvalidAddress(t *testing.T) {
+	fwd := &Forwarder{
+		Logger:  log.Default(),
+		Address: "invalid:address",
+	}
+
+	if err := fwd.Start(); err == nil {
+		t.Error("expected error for invalid address, got nil")
+	}
+}

--- a/internal/messages/handler_test.go
+++ b/internal/messages/handler_test.go
@@ -74,9 +74,9 @@ func TestHandlerParsesAllMessageTypes(t *testing.T) {
 	handler.Stop()
 
 	want := map[DogStatsDMessageType]int{
-		MetricMessageType:      2,
+		MetricMessageType:       2,
 		ServiceCheckMessageType: 2,
-		EventMessageType:       2,
+		EventMessageType:        2,
 	}
 
 	for typ, wantCount := range want {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,9 @@ func (u *udpServer) Listen() error {
 
 		// forward the raw datagram to an upstream DogStatsD server
 		if u.forward != nil {
-			u.forward(buf[:n])
+			datagram := make([]byte, n)
+			copy(datagram, buf[:n])
+			u.forward(datagram)
 		}
 
 		// copy the message and pass it to the format function

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,10 +15,11 @@ type Server interface {
 	Stop() error
 }
 
-func NewServer(addr string, fn func([]byte) error, logger *log.Logger) Server {
+func NewServer(addr string, fn func([]byte) error, forward func([]byte), logger *log.Logger) Server {
 	return &udpServer{
 		logger:        logger,
 		msgHandler:    fn,
+		forward:       forward,
 		rawAddr:       addr,
 		readDeadline:  time.Second / 4,
 		writeDeadline: time.Second / 4,
@@ -31,6 +32,7 @@ func NewServer(addr string, fn func([]byte) error, logger *log.Logger) Server {
 type udpServer struct {
 	logger        *log.Logger
 	msgHandler    func([]byte) error
+	forward       func([]byte)
 	rawAddr       string
 	readDeadline  time.Duration
 	writeDeadline time.Duration
@@ -78,6 +80,11 @@ func (u *udpServer) Listen() error {
 
 			u.errCh <- err
 			continue
+		}
+
+		// forward the raw datagram to an upstream DogStatsD server
+		if u.forward != nil {
+			u.forward(buf[:n])
 		}
 
 		// copy the message and pass it to the format function

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -161,6 +161,71 @@ func TestServerStripsCarriageReturns(t *testing.T) {
 	}
 }
 
+func TestServerForwardsDatagrams(t *testing.T) {
+	var received atomic.Int32
+	var messages [][]byte
+
+	handler := func(msg []byte) error {
+		return nil
+	}
+
+	forward := func(datagram []byte) {
+		received.Add(1)
+		cp := make([]byte, len(datagram))
+		copy(cp, datagram)
+		messages = append(messages, cp)
+	}
+
+	port := findAvailablePort(t)
+	addr := "127.0.0.1:" + port
+
+	srv := NewServer(addr, handler, forward, log.Default())
+	go func() {
+		_ = srv.Listen()
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Single message
+	_, err = conn.Write([]byte("page.views:1|c"))
+	if err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	// Multi-message datagram with \r\n
+	_, err = conn.Write([]byte("fuel.level:0.5|g\r\nsong.length:240|h"))
+	if err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("failed to stop server: %v", err)
+	}
+
+	if got := received.Load(); got != 2 {
+		t.Errorf("forwarded %d datagrams, want 2", got)
+	}
+
+	if len(messages) >= 1 {
+		if string(messages[0]) != "page.views:1|c" {
+			t.Errorf("messages[0] = %q, want %q", messages[0], "page.views:1|c")
+		}
+	}
+	if len(messages) >= 2 {
+		// Raw datagrams are forwarded as-is, including \r\n
+		if string(messages[1]) != "fuel.level:0.5|g\r\nsong.length:240|h" {
+			t.Errorf("messages[1] = %q, want %q", messages[1], "fuel.level:0.5|g\r\nsong.length:240|h")
+		}
+	}
+}
+
 func TestServerStops(t *testing.T) {
 	port := findAvailablePort(t)
 	addr := "127.0.0.1:" + port

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -163,7 +163,7 @@ func TestServerStripsCarriageReturns(t *testing.T) {
 
 func TestServerForwardsDatagrams(t *testing.T) {
 	var received atomic.Int32
-	var messages [][]byte
+	done := make(chan []byte, 2)
 
 	handler := func(msg []byte) error {
 		return nil
@@ -173,7 +173,7 @@ func TestServerForwardsDatagrams(t *testing.T) {
 		received.Add(1)
 		cp := make([]byte, len(datagram))
 		copy(cp, datagram)
-		messages = append(messages, cp)
+		done <- cp
 	}
 
 	port := findAvailablePort(t)
@@ -207,6 +207,17 @@ func TestServerForwardsDatagrams(t *testing.T) {
 
 	if err := srv.Stop(); err != nil {
 		t.Fatalf("failed to stop server: %v", err)
+	}
+
+	// Collect forwarded datagrams via channel to avoid data race
+	var messages [][]byte
+	for range int(received.Load()) {
+		select {
+		case msg := <-done:
+			messages = append(messages, msg)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for forwarded datagram")
+		}
 	}
 
 	if got := received.Load(); got != 2 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,7 +18,7 @@ func TestServerReceivesMessages(t *testing.T) {
 		return nil
 	}
 
-	srv := NewServer("127.0.0.1:0", handler, log.Default())
+	srv := NewServer("127.0.0.1:0", handler, nil, log.Default())
 
 	go func() {
 		_ = srv.Listen()
@@ -35,7 +35,7 @@ func TestServerReceivesMessages(t *testing.T) {
 	port := findAvailablePort(t)
 	addr := "127.0.0.1:" + port
 
-	srv = NewServer(addr, handler, log.Default())
+	srv = NewServer(addr, handler, nil, log.Default())
 	go func() {
 		_ = srv.Listen()
 	}()
@@ -77,7 +77,7 @@ func TestServerSplitsMultiMessageDatagrams(t *testing.T) {
 	port := findAvailablePort(t)
 	addr := "127.0.0.1:" + port
 
-	srv := NewServer(addr, handler, log.Default())
+	srv := NewServer(addr, handler, nil, log.Default())
 	go func() {
 		_ = srv.Listen()
 	}()
@@ -128,7 +128,7 @@ func TestServerStripsCarriageReturns(t *testing.T) {
 	port := findAvailablePort(t)
 	addr := "127.0.0.1:" + port
 
-	srv := NewServer(addr, handler, log.Default())
+	srv := NewServer(addr, handler, nil, log.Default())
 	go func() {
 		_ = srv.Listen()
 	}()
@@ -165,7 +165,7 @@ func TestServerStops(t *testing.T) {
 	port := findAvailablePort(t)
 	addr := "127.0.0.1:" + port
 
-	srv := NewServer(addr, func(msg []byte) error { return nil }, log.Default())
+	srv := NewServer(addr, func(msg []byte) error { return nil }, nil, log.Default())
 	go func() {
 		_ = srv.Listen()
 	}()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -211,7 +211,7 @@ func TestServerForwardsDatagrams(t *testing.T) {
 
 	// Collect forwarded datagrams via channel to avoid data race
 	var messages [][]byte
-	for range int(received.Load()) {
+	for range received.Load() {
 		select {
 		case msg := <-done:
 			messages = append(messages, msg)


### PR DESCRIPTION
Add a --forward flag to forward raw DogStatsD datagrams to an upstream server. Implements a Forwarder with Start, Forward, and Stop methods. Integrates forwarding into the UDP server and main entrypoint.

Implements: #1 