### PR TITLE
Upgrade Go toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mroyme/dogstatsd-local
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/catppuccin/go v0.3.0


### PR DESCRIPTION
## Summary
- Update the module toolchain to `go1.26.4` while keeping the `go 1.26.0` directive as the minimum supported version.

## Testing
- Not run (not requested)