### PR TITLE
build(goreleaser): configure conventional changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,14 +100,58 @@ signs:
 changelog:
   sort: asc
   use: github
+  groups:
+    - title: "⚠ BREAKING CHANGES"
+      regexp: '^.*?[[:alpha:]][[:alnum:]-]*(\([^)]+\))?!: .+$'
+      order: 0
+    - title: Features
+      regexp: '^.*?feat(\([^)]+\))?!?: .+$'
+      order: 1
+    - title: Bug Fixes
+      regexp: '^.*?fix(\([^)]+\))?!?: .+$'
+      order: 2
+    - title: Performance Improvements
+      regexp: '^.*?perf(\([^)]+\))?!?: .+$'
+      order: 3
+    - title: Reverts
+      regexp: '^.*?revert: .+$'
+      order: 4
+    - title: Documentation
+      regexp: '^.*?docs(\([^)]+\))?!?: .+$'
+      order: 5
+    - title: Styles
+      regexp: '^.*?style(\([^)]+\))?!?: .+$'
+      order: 6
+    - title: Chores
+      regexp: '^.*?chore(\([^)]+\))?!?: .+$'
+      order: 7
+    - title: Code Refactoring
+      regexp: '^.*?refactor(\([^)]+\))?!?: .+$'
+      order: 8
+    - title: Tests
+      regexp: '^.*?test(\([^)]+\))?!?: .+$'
+      order: 9
+    - title: Build System
+      regexp: '^.*?build(\([^)]+\))?!?: .+$'
+      order: 10
+    - title: Continuous Integration
+      regexp: '^.*?ci(\([^)]+\))?!?: .+$'
+      order: 11
   filters:
+    include:
+      - "^[[:alpha:]][[:alnum:]-]*(\\([^)]+\\))?!: .+$"
+      - "^feat(\\([^)]+\\))?!?: .+$"
+      - "^fix(\\([^)]+\\))?!?: .+$"
+      - "^perf(\\([^)]+\\))?!?: .+$"
+      - "^revert: .+$"
+      - "^docs(\\([^)]+\\))?!?: .+$"
+      - "^style(\\([^)]+\\))?!?: .+$"
+      - "^chore(\\([^)]+\\))?!?: .+$"
+      - "^refactor(\\([^)]+\\))?!?: .+$"
+      - "^test(\\([^)]+\\))?!?: .+$"
+      - "^build(\\([^)]+\\))?!?: .+$"
+      - "^ci(\\([^)]+\\))?!?: .+$"
     exclude:
-      - "^ci:"
-      - "^docs:"
-      - "^mise:"
-      - "^test:"
-      - "^chore:"
-      - "^build:"
       - Merge pull request
       - Merge branch
 


### PR DESCRIPTION
## Summary

- Configure GoReleaser changelog groups to mirror conventional-changelog conventional commits sections.
- Include visible sections for breaking changes, features, bug fixes, performance improvements, reverts, and standard types such as docs, style, chore, refactor, test, build, and ci.
- Replace broad exclusions with explicit includes so release notes only contain supported conventional commit headers.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".goreleaser.yml"); puts "ok"'`
- `git diff --check`

Note: `goreleaser` is not installed in the local shell, so I could not run `goreleaser check`.
