### PR TITLE
chore: remove GitHub Pages CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-dogstatsd.mroy.dev


### PR DESCRIPTION
## Summary

- Remove `docs/CNAME`, which is no longer needed now that GitHub Pages is managed through Actions.

## Impact

- Prevents the static Pages source from carrying an obsolete custom domain configuration.
- Leaves the Actions-based GitHub Pages workflow as the source of deployment configuration.

## Validation

- `go test -v ./...`